### PR TITLE
MVP YAML converter: streaming UI + API with LLM integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .nuxt
 .nitro
 .cache
+.eslintcache
 dist
 
 # Node dependencies

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,5 +3,5 @@ import { defineConfig } from 'drizzle-kit'
 export default defineConfig({
   dialect: 'sqlite',
   schema: './server/database/schema.ts',
-  out: './server/database/migrations'
+  out: './server/database/migrations',
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,9 +7,10 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-05-15',
   nitro: { experimental: { openAPI: true } },
   hub: {
+    bindings: { compatibilityDate: '2025-05-05' },
     workers: true,
     database: true,
-    bindings: { compatibilityDate: '2025-05-05' },
+    ai: true,
   },
   eslint: {
     config: { stylistic: true },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "drizzle-kit": "^0.31.1",
     "eslint": "^9.28.0",
     "typescript": "^5.8.3",
+    "vite-plugin-eslint2": "^5.0.3",
     "wrangler": "^4.19.1"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,63 @@
+<script setup lang="ts">
+const input = ref('')
+const output = ref('')
+const loading = ref(false)
+
+async function convert() {
+  output.value = ''
+  loading.value = true
+  console.log('convert')
+
+  const response = await $fetch<ReadableStream>('/api/convert', {
+    method: 'POST',
+    body: input.value,
+    responseType: 'stream',
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  })
+
+  let buffer = ''
+  const reader = response.pipeThrough(new TextDecoderStream()).getReader()
+
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) {
+      if (buffer.trim()) console.warn('Stream ended with unparsed data:', buffer)
+      break
+    }
+
+    buffer += value
+    const lines = buffer.split('\n')
+    buffer = lines.pop() || ''
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue
+      const data = line.slice('data: '.length).trim()
+
+      try {
+        const jsonData = JSON.parse(data)
+        if (jsonData.response) output.value += jsonData.response
+      }
+      catch (parseError) {
+        console.warn('Error parsing JSON:', parseError)
+      }
+    }
+  }
+
+  loading.value = false
+}
+</script>
+
 <template>
-  <UPageHero title="Hey" />
+  <UPageSection>
+    <UPageHero title="Hey" />
+    <UTextarea v-model="input" />
+    <UButton
+      label="Convert"
+      :loading
+      @click="convert"
+    />
+    <pre>{{ output }}</pre>
+  </UPageSection>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.4.1
-        version: 1.4.1(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))
+        version: 1.4.1(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite-plugin-eslint2@5.0.3(eslint@9.28.0(jiti@2.4.2))(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))
       drizzle-kit:
         specifier: ^0.31.1
         version: 0.31.1
@@ -33,6 +33,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vite-plugin-eslint2:
+        specifier: ^5.0.3
+        version: 5.0.3(eslint@9.28.0(jiti@2.4.2))(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))
       wrangler:
         specifier: ^4.19.1
         version: 4.19.1(@cloudflare/workers-types@4.20250607.0)
@@ -5157,6 +5160,20 @@ packages:
       vue-tsc:
         optional: true
 
+  vite-plugin-eslint2@5.0.3:
+    resolution: {integrity: sha512-kbjjbSyxSYK1oK0kOnSVs2er8DhqNbVA5pNN21SJo8AldQIOgG4LVQvwp6ISYMDXQaaBMOCrmXFTfGkQUjIZ1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/eslint': ^7.0.0 || ^8.0.0 || ^9.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      rollup:
+        optional: true
+
   vite-plugin-inspect@11.1.0:
     resolution: {integrity: sha512-r3Nx8xGQ08bSoNu7gJGfP5H/wNOROHtv0z3tWspplyHZJlABwNoPOdFEmcVh+lVMDyk/Be4yt8oS596ZHoYhOg==}
     engines: {node: '>=14'}
@@ -6484,7 +6501,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.4.1(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))':
+  '@nuxt/eslint@1.4.1(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite-plugin-eslint2@5.0.3(eslint@9.28.0(jiti@2.4.2))(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))':
     dependencies:
       '@eslint/config-inspector': 1.1.0(eslint@9.28.0(jiti@2.4.2))
       '@nuxt/devtools-kit': 2.5.0(magicast@0.3.5)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))
@@ -6500,6 +6517,8 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
       unimport: 5.0.1
+    optionalDependencies:
+      vite-plugin-eslint2: 5.0.3(eslint@9.28.0(jiti@2.4.2))(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
@@ -11014,6 +11033,17 @@ snapshots:
       eslint: 9.28.0(jiti@2.4.2)
       optionator: 0.9.4
       typescript: 5.8.3
+
+  vite-plugin-eslint2@5.0.3(eslint@9.28.0(jiti@2.4.2))(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
+      debug: 4.4.1
+      eslint: 9.28.0(jiti@2.4.2)
+      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0)
+    optionalDependencies:
+      rollup: 4.42.0
+    transitivePeerDependencies:
+      - supports-color
 
   vite-plugin-inspect@11.1.0(@nuxt/kit@3.17.5(magicast@0.3.5))(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(yaml@2.8.0)):
     dependencies:

--- a/server/api/convert.post.ts
+++ b/server/api/convert.post.ts
@@ -1,0 +1,33 @@
+const system = `
+You are an assistant specialized in converting raw text (logs, configurations, command outputs, etc.) into structured YAML.
+
+Rules:
+- The entire input is content to convert. Never skip lines.
+- Infer the implicit structure and reflect it accurately in YAML.
+- Use valid YAML types (int, bool, string, lists, dictionaries).
+- Do not output anything outside the YAML block (no intros, no comments).
+- Preserve YAML indentation.
+- If a value is ambiguous, keep it as a string — do not guess.
+
+Always respond with a valid YAML document only.
+`.trim()
+
+export default defineEventHandler(async (event) => {
+  const prompt = (await readBody<string>(event)).trim()
+
+  if (!prompt)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Raw prompt content is required in the POST body.',
+    })
+
+  const messages = [
+    { role: 'system', content: system },
+    { role: 'user', content: prompt },
+  ]
+
+  return await hubAI().run('@cf/meta/llama-3.1-8b-instruct', {
+    stream: true,
+    messages,
+  })
+})


### PR DESCRIPTION
This PR introduces the first working version of the YAML converter MVP:

* Adds a `/api/convert` endpoint using `@cf/meta/llama-3.1-8b-instruct` with streaming
* Provides a simple UI (`/`) to input raw text and display YAML output
* Implements `TextDecoderStream` parsing for SSE responses
* Adds `.eslintcache` to `.gitignore`
* Enables `vite-plugin-eslint2` in `devDependencies`
* Adds `dependabot.yml` for automated npm updates
